### PR TITLE
Accounting for TI changes to strings for better security

### DIFF
--- a/core-overloads.boba
+++ b/core-overloads.boba
@@ -132,8 +132,8 @@ effect test-check!
 
 func test-check-handler test-success test-name failed =
     if test-success
-    then { test-name " succeeded.\n" }
-    else { test-name " failed.\n" }
+    then { test-name " succeeded.\n" clear-string }
+    else { test-name " failed.\n" clear-string }
     concat-string
     print-string
 


### PR DESCRIPTION
String literals no longer cleared by default